### PR TITLE
Set project CSTD property to c11

### DIFF
--- a/apps/sensor-default/CMakeLists.txt
+++ b/apps/sensor-default/CMakeLists.txt
@@ -3,12 +3,13 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+set(CMAKE_C_STANDARD 11)
+set_property(GLOBAL PROPERTY CSTD c11)
+
 # include top-level application defines
 include(../../cmake/app.cmake)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-
-set(CMAKE_C_STANDARD 11)
 
 project(sensor-default)
 target_sources(app PRIVATE src/main.c)

--- a/apps/sensor-memfault/CMakeLists.txt
+++ b/apps/sensor-memfault/CMakeLists.txt
@@ -3,12 +3,14 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+set(CMAKE_C_STANDARD 11)
+set_property(GLOBAL PROPERTY CSTD c11)
+
 # include top-level application defines
 include(../../cmake/app.cmake)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
-set(CMAKE_C_STANDARD 11)
 
 project(sensor-memfault)
 target_sources(app PRIVATE src/main.c)


### PR DESCRIPTION
This fixes a problem where the Mac Zephyr toolchain could not build the project due to different compiler defaults for cstd