### PR TITLE
Update README to fix typo and missing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setting up your workspace
 
-First, create a Zephyr workspace (i.e., directory) that will house this repo along with  the other repos that this project pulls in. 
+First, create a Zephyr workspace (i.e., directory) that will house this repo along with  the other repos that this project pulls in.
 
 Change to the workspace directory and clone this repo. e.g.,
 
@@ -25,8 +25,10 @@ west update
 In the top-level workspace directory, start a build with
 
 ```
-west build -d <board> </path/to/application>
+west build -b <board> -s <path to application>
 ```
+
+Where `<path to application>` is likely one of the projects in the `apps` directory of this repo (e.g., `apps/sensor-default`)
 
 ## Flashing the application
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,23 @@ west update
 In the top-level workspace directory, start a build with
 
 ```
-west build -b <board> -s <path to application>
+west build --sysbuild -b <board> <path_to_application>
 ```
 
-Where `<path to application>` is likely one of the projects in the `apps` directory of this repo (e.g., `apps/sensor-default`)
+Where `<path_to_application>` is one of the projects in the `apps` directory of this repo (e.g., `apps/sensor-default`)
 
 ## Flashing the application
 
 ```
 west flash
 ```
+
+## Using an alternative programmer to flash the firmware
+
+If you need to flash the application using an alternative programmer (e.g., the Nordic nRF Connect Programmer), use the
+`merged.hex` file found in the `build/` directory.
+
+## Uploading the firmware for OTA
+
+For OTA, you will need to use the `build/<appname>/zephyr/zephyr.signed.bin` firmware (signed firmware in `.bin` format, without
+the bootloader).


### PR DESCRIPTION
Fix `-b` typo and add `--sysbuild` option. Also add instructions about which build output file to use for flashing and OTA. Fixes the typo identified in #1 