### PR TITLE
Dynamically detect flash parameters on kkm-s5

### DIFF
--- a/boards/kkm/kkm_s5_bcn/kkm_s5_bcn.dts
+++ b/boards/kkm/kkm_s5_bcn/kkm_s5_bcn.dts
@@ -177,7 +177,7 @@
         fm25q04: fm25q04b@0 {
                 compatible = "jedec,spi-nor";
                 reg = <0>;
-                spi-max-frequency = <104000000>;
+                spi-max-frequency = <100000000>;
                 jedec-id = [a1 40 13];
                 sfdp-bfp = [
                         e5 20 f1 ff  ff ff 3f 00  44 eb 08 6b  08 3b 80 bb

--- a/boards/kkm/kkm_s5_bcn/kkm_s5_bcn_defconfig
+++ b/boards/kkm/kkm_s5_bcn/kkm_s5_bcn_defconfig
@@ -12,3 +12,6 @@ CONFIG_USE_SEGGER_RTT=y
 
 # enable GPIO
 CONFIG_GPIO=y
+
+# dynamically detect flash part
+CONFIG_SPI_NOR_SFDP_RUNTIME=y


### PR DESCRIPTION
KKM can populate either the fm25q04 OR the fm25w04 4Mb flash part on the KKM-S5. To accomodate both parts, this PR lowers the max SPI frequency to 100MHz, which is the maximum the fm25w04 supports. Also change board configuration to do dynamic SFDP discovery, which bypasses zephyr's static jedec-id check as that would fail when the w04 part is used.