### PR TITLE
Rewrite battery measurement code to use device tree configuration

### DIFF
--- a/apps/sensor-default/boards/kkm_s5_bcn.overlay
+++ b/apps/sensor-default/boards/kkm_s5_bcn.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Blecon Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    zephyr,user {
+		io-channels = <&adc 0>;
+	};
+};

--- a/apps/sensor-default/boards/nrf52840dk_nrf52840.overlay
+++ b/apps/sensor-default/boards/nrf52840dk_nrf52840.overlay
@@ -7,14 +7,14 @@
     chosen {
         nordic,pm-ext-flash = &mx25r64;
     };
-    
+
     zephyr,user {
-		io-channels = <&adc 4>;
+		io-channels = <&adc 0>;
 	};
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";        
+    compatible = "nordic,nrf-twim";
     clock-frequency = <I2C_BITRATE_FAST>;
 
     sht4x: sht4x@44 {
@@ -39,4 +39,19 @@
         int2-gpio-config = <1>;
         status = "okay";
     };
+};
+
+&adc {
+    #address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
 };

--- a/apps/sensor-memfault/boards/kkm_s5_bcn.overlay
+++ b/apps/sensor-memfault/boards/kkm_s5_bcn.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Blecon Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    zephyr,user {
+		io-channels = <&adc 0>;
+	};
+};

--- a/apps/sensor-memfault/boards/nrf52840dk_nrf52840.overlay
+++ b/apps/sensor-memfault/boards/nrf52840dk_nrf52840.overlay
@@ -7,14 +7,14 @@
     chosen {
         nordic,pm-ext-flash = &mx25r64;
     };
-    
+
     zephyr,user {
 		io-channels = <&adc 4>;
 	};
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";        
+    compatible = "nordic,nrf-twim";
     clock-frequency = <I2C_BITRATE_FAST>;
 
     sht4x: sht4x@44 {
@@ -39,4 +39,19 @@
         int2-gpio-config = <1>;
         status = "okay";
     };
+};
+
+&adc {
+    #address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
 };

--- a/boards/kkm/kkm_s5_bcn/kkm_s5_bcn.dts
+++ b/boards/kkm/kkm_s5_bcn/kkm_s5_bcn.dts
@@ -49,10 +49,6 @@
 		};
 	};
 
-	zephyr,user {
-		io-channels = <&adc 4>;
-	};
-
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
@@ -64,6 +60,18 @@
 
 &adc {
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_VDD>;
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
 };
 
 &uicr {

--- a/lib/battery/include/battery/battery.h
+++ b/lib/battery/include/battery/battery.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Peter Bigot Consulting, LLC
+ * Copyright (c) 2025 Blecon Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,47 +7,11 @@
 #ifndef APPLICATION_BATTERY_H_
 #define APPLICATION_BATTERY_H_
 
-/** Enable or disable measurement of the battery voltage.
- *
- * @param enable true to enable, false to disable
- *
- * @return zero on success, or a negative error code.
- */
-int battery_measure_enable(bool enable);
-
 /** Measure the battery voltage.
  *
  * @return the battery voltage in millivolts, or a negative error
  * code.
  */
 int battery_sample(void);
-
-/** A point in a battery discharge curve sequence.
- *
- * A discharge curve is defined as a sequence of these points, where
- * the first point has #lvl_pptt set to 10000 and the last point has
- * #lvl_pptt set to zero.  Both #lvl_pptt and #lvl_mV should be
- * monotonic decreasing within the sequence.
- */
-struct battery_level_point {
-	/** Remaining life at #lvl_mV. */
-	uint16_t lvl_pptt;
-
-	/** Battery voltage at #lvl_pptt remaining life. */
-	uint16_t lvl_mV;
-};
-
-/** Calculate the estimated battery level based on a measured voltage.
- *
- * @param batt_mV a measured battery voltage level.
- *
- * @param curve the discharge curve for the type of battery installed
- * on the system.
- *
- * @return the estimated remaining capacity in parts per ten
- * thousand.
- */
-unsigned int battery_level_pptt(unsigned int batt_mV,
-				const struct battery_level_point *curve);
 
 #endif /* APPLICATION_BATTERY_H_ */

--- a/lib/battery/src/battery.c
+++ b/lib/battery/src/battery.c
@@ -23,8 +23,8 @@
 static const struct adc_dt_spec vdd_adc =
     ADC_DT_SPEC_GET_BY_IDX(DT_PATH(zephyr_user), 0);
 
-bool _battery_ready = false;
-bool _needs_calibrate = true;
+static bool _battery_ready = false;
+static bool _needs_calibrate = true;
 
 static int battery_setup(void)
 {

--- a/lib/battery/src/battery.c
+++ b/lib/battery/src/battery.c
@@ -1,231 +1,91 @@
 /*
- * Copyright (c) 2018-2019 Peter Bigot Consulting, LLC
- * Copyright (c) 2019-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Blecon Ltd
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include <zephyr/kernel.h>
-#include <zephyr/init.h>
-#include <zephyr/drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/adc.h>
-#include <zephyr/drivers/sensor.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include "battery/battery.h"
-
-LOG_MODULE_REGISTER(BATTERY, CONFIG_ADC_LOG_LEVEL);
-
-#define VBATT DT_PATH(vbatt)
-#define ZEPHYR_USER DT_PATH(zephyr_user)
-
-#ifdef CONFIG_BOARD_THINGY52_NRF52832
-/* This board uses a divider that reduces max voltage to
- * reference voltage (600 mV).
- */
-#define BATTERY_ADC_GAIN ADC_GAIN_1
-#else
-/* Other boards may use dividers that only reduce battery voltage to
- * the maximum supported by the hardware (3.6 V)
- */
-#define BATTERY_ADC_GAIN ADC_GAIN_1_6
+#if !DT_NODE_EXISTS(DT_PATH(zephyr_user)) || \
+	!DT_NODE_HAS_PROP(DT_PATH(zephyr_user), io_channels)
+#error "No suitable devicetree overlay specified"
 #endif
 
-struct io_channel_config {
-	uint8_t channel;
-};
+static const struct adc_dt_spec vdd_adc =
+    ADC_DT_SPEC_GET_BY_IDX(DT_PATH(zephyr_user), 0);
 
-struct divider_config {
-	struct io_channel_config io_channel;
-	struct gpio_dt_spec power_gpios;
-	/* output_ohm is used as a flag value: if it is nonzero then
-	 * the battery is measured through a voltage divider;
-	 * otherwise it is assumed to be directly connected to Vdd.
-	 */
-	uint32_t output_ohm;
-	uint32_t full_ohm;
-};
-
-static const struct divider_config divider_config = {
-#if DT_NODE_HAS_STATUS(VBATT, okay)
-	.io_channel = {
-		DT_IO_CHANNELS_INPUT(VBATT),
-	},
-	.power_gpios = GPIO_DT_SPEC_GET_OR(VBATT, power_gpios, {}),
-	.output_ohm = DT_PROP(VBATT, output_ohms),
-	.full_ohm = DT_PROP(VBATT, full_ohms),
-#else /* /vbatt exists */
-	.io_channel = {
-		DT_IO_CHANNELS_INPUT(ZEPHYR_USER),
-	},
-#endif /* /vbatt exists */
-};
-
-struct divider_data {
-	const struct device *adc;
-	struct adc_channel_cfg adc_cfg;
-	struct adc_sequence adc_seq;
-	int16_t raw;
-};
-static struct divider_data divider_data = {
-#if DT_NODE_HAS_STATUS(VBATT, okay)
-	.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(VBATT)),
-#else
-	.adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(ZEPHYR_USER)),
-#endif
-};
-
-static int divider_setup(void)
-{
-	const struct divider_config *cfg = &divider_config;
-	const struct io_channel_config *iocp = &cfg->io_channel;
-	const struct gpio_dt_spec *gcp = &cfg->power_gpios;
-	struct divider_data *ddp = &divider_data;
-	struct adc_sequence *asp = &ddp->adc_seq;
-	struct adc_channel_cfg *accp = &ddp->adc_cfg;
-	int rc;
-
-	if (!device_is_ready(ddp->adc)) {
-		LOG_ERR("ADC device is not ready %s", ddp->adc->name);
-		return -ENOENT;
-	}
-
-	if (gcp->port) {
-		if (!device_is_ready(gcp->port)) {
-			LOG_ERR("%s: device not ready", gcp->port->name);
-			return -ENOENT;
-		}
-		rc = gpio_pin_configure_dt(gcp, GPIO_OUTPUT_INACTIVE);
-		if (rc != 0) {
-			LOG_ERR("Failed to control feed %s.%u: %d",
-				gcp->port->name, gcp->pin, rc);
-			return rc;
-		}
-	}
-
-	*asp = (struct adc_sequence){
-		.channels = BIT(0),
-		.buffer = &ddp->raw,
-		.buffer_size = sizeof(ddp->raw),
-		.oversampling = 4,
-		.calibrate = true,
-	};
-
-#ifdef CONFIG_ADC_NRFX_SAADC
-	*accp = (struct adc_channel_cfg){
-		.gain = BATTERY_ADC_GAIN,
-		.reference = ADC_REF_INTERNAL,
-		.acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40),
-	};
-
-	if (cfg->output_ohm != 0) {
-		accp->input_positive = SAADC_CH_PSELP_PSELP_AnalogInput0
-			+ iocp->channel;
-	} else {
-		accp->input_positive = SAADC_CH_PSELP_PSELP_VDD;
-	}
-
-	asp->resolution = 14;
-#else /* CONFIG_ADC_var */
-#error Unsupported ADC
-#endif /* CONFIG_ADC_var */
-
-	rc = adc_channel_setup(ddp->adc, accp);
-	LOG_INF("Setup AIN%u got %d", iocp->channel, rc);
-
-	return rc;
-}
-
-static bool battery_ok;
+bool _battery_ready = false;
+bool _needs_calibrate = true;
 
 static int battery_setup(void)
 {
-	int rc = divider_setup();
+    int err;
 
-	battery_ok = (rc == 0);
-	LOG_INF("Battery setup: %d %d", rc, battery_ok);
-	return rc;
+    if (!adc_is_ready_dt(&vdd_adc)) {
+        printk("ADC controller device %s not ready\n", vdd_adc.dev->name);
+        return 0;
+    }
+
+    err = adc_channel_setup_dt(&vdd_adc);
+    if (err < 0) {
+        printk("Could not setup battery adc channel: %d\n", err);
+        return 0;
+    }
+
+    _battery_ready = true;
+    return 0;
 }
-
 SYS_INIT(battery_setup, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
-
-int battery_measure_enable(bool enable)
-{
-	int rc = -ENOENT;
-
-	if (battery_ok) {
-		const struct gpio_dt_spec *gcp = &divider_config.power_gpios;
-
-		rc = 0;
-		if (gcp->port) {
-			rc = gpio_pin_set_dt(gcp, enable);
-		}
-	}
-	return rc;
-}
 
 int battery_sample(void)
 {
 	int rc = -ENOENT;
+    int err;
+	int16_t buf;
 
-	if (battery_ok) {
-		struct divider_data *ddp = &divider_data;
-		const struct divider_config *dcp = &divider_config;
-		struct adc_sequence *sp = &ddp->adc_seq;
+    if (!_battery_ready) {
+        printk("Battery ADC not ready\n");
+        return rc;
+    }
 
-		rc = adc_read(ddp->adc, sp);
-		sp->calibrate = false;
-		if (rc == 0) {
-			int32_t val = ddp->raw;
+    struct adc_sequence sequence = {
+		.buffer = &buf,
+		/* buffer size in bytes, not number of samples */
+		.buffer_size = sizeof(buf),
+        .calibrate = _needs_calibrate,
+	};
 
-			adc_raw_to_millivolts(adc_ref_internal(ddp->adc),
-					      ddp->adc_cfg.gain,
-					      sp->resolution,
-					      &val);
+    _needs_calibrate = false;
 
-			if (dcp->output_ohm != 0) {
-				rc = val * (uint64_t)dcp->full_ohm
-					/ dcp->output_ohm;
-				LOG_INF("raw %u ~ %u mV => %d mV\n",
-					ddp->raw, val, rc);
-			} else {
-				rc = val;
-				LOG_INF("raw %u ~ %u mV\n", ddp->raw, val);
-			}
-		}
-	}
+    err = adc_sequence_init_dt(&vdd_adc, &sequence);
+    if (err < 0) {
+        printk("Could not init ADC sequence (%d)\n", err);
+        return rc;
+    }
 
-	return rc;
-}
+    err = adc_read_dt(&vdd_adc, &sequence);
+    if (err < 0) {
+        printk("Could not read (%d)\n", err);
+        return rc;
+    }
 
-unsigned int battery_level_pptt(unsigned int batt_mV,
-				const struct battery_level_point *curve)
-{
-	const struct battery_level_point *pb = curve;
+    int32_t battery_mv = buf;
 
-	if (batt_mV >= pb->lvl_mV) {
-		/* Measured voltage above highest point, cap at maximum. */
-		return pb->lvl_pptt;
-	}
-	/* Go down to the last point at or below the measured voltage. */
-	while ((pb->lvl_pptt > 0)
-	       && (batt_mV < pb->lvl_mV)) {
-		++pb;
-	}
-	if (batt_mV < pb->lvl_mV) {
-		/* Below lowest point, cap at minimum */
-		return pb->lvl_pptt;
-	}
+	err = adc_raw_to_millivolts_dt(&vdd_adc, &battery_mv);
+    if (err < 0) {
+        printk("Could not convert raw sample to millivolts (%d)\n", err);
+    }
 
-	/* Linear interpolation between below and above points. */
-	const struct battery_level_point *pa = pb - 1;
+    printk("battery raw: %d ~ %d mV\n", buf, battery_mv);
 
-	return pb->lvl_pptt
-	       + ((pa->lvl_pptt - pb->lvl_pptt)
-		  * (batt_mV - pb->lvl_mV)
-		  / (pa->lvl_mV - pb->lvl_mV));
+	return battery_mv;
 }


### PR DESCRIPTION
Rewrite battery measurement code to take configuration from the devicetree, in line with Zephyr best-practices. The previous battery measurement code was taken from a Nordic example. Although the previous code used the Zephyr ADC API, it used constants and settings specific to the nRF52. 

The new code populates the ADC API structures from devicetree, which the battery voltage measurement library can support other SoCs and boards that have different ways of connecting the battery to the ADC. 

The PR adds devicetree nodes to supported boards. The new channel sub-node in the adc node describes how the internal VDD is connected to the ADC and sets appropriate gain values so that the battery voltage is within the range of the internal voltage reference.