### PR TITLE
Add  Blecon status LED library

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,9 @@ config BLECON_LIB_OTA
 config BLECON_LIB_MOTION
     bool "Motion module"
     default n
+config BLECON_LIB_LED
+    bool "Status LED module"
+    default n
 config BLECON_APP_VERSION
     string "Blecon App version (semver)"
     default "0.0.0"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,3 +4,4 @@
 add_subdirectory_ifdef(CONFIG_BLECON_LIB_BATTERY battery)
 add_subdirectory_ifdef(CONFIG_BLECON_LIB_OTA ota)
 add_subdirectory_ifdef(CONFIG_BLECON_LIB_MOTION motion)
+add_subdirectory_ifdef(CONFIG_BLECON_LIB_LED led)

--- a/lib/led/CMakeLists.txt
+++ b/lib/led/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) Blecon Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(src/blecon_led.c)
+zephyr_library_include_directories(include)
+zephyr_include_directories(include)

--- a/lib/led/include/led/blecon_led.h
+++ b/lib/led/include/led/blecon_led.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Blecon Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+
+enum blecon_led_connection_state_t {
+    blecon_led_connection_state_disconnected,
+    blecon_led_connection_state_connecting,
+    blecon_led_connection_state_connected,
+};
+
+/// @brief Set LED device and number as the Blecon status LED
+/// @param led_device
+/// @param led_num
+void blecon_led_init(const struct device* led_device, uint32_t led_num);
+
+/// @brief Indicate data activity on the Blecon LED
+void blecon_led_data_activity();
+
+/// @brief Set Blecon LED connnection state
+/// @param state
+void blecon_led_set_connection_state(enum blecon_led_connection_state_t state);
+
+/// @brief Indicate that Blecon is announcing device ID
+void blecon_led_set_announce(bool state);

--- a/lib/led/src/blecon_led.c
+++ b/lib/led/src/blecon_led.c
@@ -13,10 +13,10 @@
 #define ANNOUNCE_DURATION_MS 5000
 
 // LED blink patterns
-const uint32_t heartbeat_pattern[] = {30, 2000};
-const uint32_t announce_pattern[] = {100, 100};
-const uint32_t connecting_pattern[] = {30, 400};
-const uint32_t connected_pattern[] = {0};
+static const uint32_t heartbeat_pattern[] = {30, 2000};
+static const uint32_t announce_pattern[] = {100, 100};
+static const uint32_t connecting_pattern[] = {30, 400};
+static const uint32_t connected_pattern[] = {0};
 
 static struct k_thread _blecon_led_thread_data;
 static const struct device* _led_device;

--- a/lib/led/src/blecon_led.c
+++ b/lib/led/src/blecon_led.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Blecon Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/drivers/led.h>
+
+#include "led/blecon_led.h"
+
+#define BLECON_LED_THREAD_STACK_SIZE 256
+#define BLECON_LED_THREAD_PRIORITY 5
+
+#define BLINK_DELAY_MS 30
+#define ANNOUNCE_DURATION_MS 5000
+
+// LED blink patterns
+uint32_t heartbeat_pattern[] = {30, 2000};
+uint32_t announce_pattern[] = {100, 100};
+uint32_t connecting_pattern[] = {30, 400};
+uint32_t connected_pattern[] = {0};
+
+struct k_thread _blecon_led_thread_data;
+const struct device* _led_device;
+uint32_t _led_num;
+bool _is_announcing = false;
+bool _data_activity = false;
+bool _has_heartbeat = false;
+enum blecon_led_connection_state_t _connection_state = blecon_led_connection_state_disconnected;
+
+static void blecon_led_thread_entry(void *, void *, void *);
+
+K_SEM_DEFINE(blecon_led_sem, 0, 1);
+K_THREAD_STACK_DEFINE(blecon_led_thread_area, BLECON_LED_THREAD_STACK_SIZE);
+
+void blecon_led_init(const struct device* led_device, uint32_t led_num) {
+    _led_device = led_device;
+    _led_num = led_num;
+    _connection_state = blecon_led_connection_state_disconnected;
+
+    k_thread_create(&_blecon_led_thread_data, blecon_led_thread_area,
+        K_THREAD_STACK_SIZEOF(blecon_led_thread_area),
+        blecon_led_thread_entry,
+        NULL, NULL, NULL,
+        BLECON_LED_THREAD_PRIORITY, 0, K_NO_WAIT);
+}
+
+static void blecon_led_thread_entry(void* unused1, void* unused2, void* unused3) {
+    k_timeout_t next_frame_time = K_NO_WAIT;
+    uint32_t delay = 0;
+    bool blink = false;
+    size_t pattern_frame = 0;
+
+    while(true) {
+        k_sem_take(&blecon_led_sem, next_frame_time);
+
+        if(_is_announcing) {
+            pattern_frame = pattern_frame % ARRAY_SIZE(announce_pattern);
+            delay = announce_pattern[pattern_frame];
+        }
+        else {
+            switch(_connection_state) {
+                case blecon_led_connection_state_disconnected:
+                    if (_has_heartbeat) {
+                        pattern_frame = pattern_frame % ARRAY_SIZE(heartbeat_pattern);
+                        delay = heartbeat_pattern[pattern_frame];
+                    }
+                    else {
+                        pattern_frame = 1;
+                        delay = 0;
+                    }
+                    break;
+                case blecon_led_connection_state_connecting:
+                    pattern_frame = pattern_frame % ARRAY_SIZE(connecting_pattern);
+                    delay = connecting_pattern[pattern_frame];
+                    break;
+                case blecon_led_connection_state_connected:
+                    if(_data_activity) {
+                        led_off(_led_device, _led_num);
+                        _data_activity = false;
+                        blink = true;
+                        delay = BLINK_DELAY_MS;
+                    }
+                    else {
+                        pattern_frame = pattern_frame % ARRAY_SIZE(connected_pattern);
+                        delay = connected_pattern[pattern_frame];
+                    }
+                    break;
+            }
+        }
+
+        if(blink) {
+            blink = false;
+        }
+        else {
+            if(pattern_frame % 2 == 0) {
+                led_on(_led_device, _led_num);
+            }
+            else {
+                led_off(_led_device, _led_num);
+            }
+            pattern_frame += 1;
+        }
+
+        // Wait until next frame for pattern (or state change)
+        if(delay == 0) {
+            next_frame_time = K_FOREVER;
+        }
+        else {
+            next_frame_time = K_MSEC(delay);
+        }
+    }
+}
+
+void blecon_led_data_activity() {
+    _data_activity = true;
+    k_sem_give(&blecon_led_sem);
+}
+
+void blecon_led_set_connection_state(enum blecon_led_connection_state_t conn_state) {
+    _connection_state = conn_state;
+    k_sem_give(&blecon_led_sem);
+}
+
+void blecon_led_set_announce(bool state) {
+    _is_announcing = state;
+    k_sem_give(&blecon_led_sem);
+}
+
+void blecon_led_set_heartbeat(bool state) {
+    _has_heartbeat = state;
+    k_sem_give(&blecon_led_sem);
+}


### PR DESCRIPTION
Add the status LED functionality from the SDK's devboard demo as a library. Currently, apps use the PWM hardware to generate the blinking announce pattern. However, some parts have a maximum PWM period that is shorter than the desired blink rate. The status LED library addresses this problem and also supports different blink patterns not possible with basic PWM (e.g., short blink followed by long blink). 

