### PR TITLE
Adjust internal load capacitance for 32KHz crystal

### DIFF
--- a/boards/mokosmart/mkbnl02sn/nrf54l15_cpuapp_common.dtsi
+++ b/boards/mokosmart/mkbnl02sn/nrf54l15_cpuapp_common.dtsi
@@ -27,13 +27,11 @@
 };
 
 &lfxo {
-	/* load-capacitors = "external"; */
 	load-capacitors = "internal";
-	load-capacitance-femtofarad = <15500>;
+	load-capacitance-femtofarad = <5500>;
 };
 
 &hfxo {
-	/* load-capacitors = "external";*/
 	load-capacitors = "internal";
 	load-capacitance-femtofarad = <15000>;
 };


### PR DESCRIPTION
Mokosmart have advised setting the internal load capacitance to 5.5pF. This, along with the 20pF external loading capacitors, results in optimal accuracy for the 32KHz crystal.