### PR TITLE
Stop announce LED as delayed work

### DIFF
--- a/lib/led/include/led/blecon_led.h
+++ b/lib/led/include/led/blecon_led.h
@@ -27,3 +27,6 @@ void blecon_led_set_connection_state(enum blecon_led_connection_state_t state);
 
 /// @brief Indicate that Blecon is announcing device ID
 void blecon_led_set_announce(bool state);
+
+/// @brief Set whether LED displays a heartbeat pattern
+void blecon_led_set_heartbeat(bool state);


### PR DESCRIPTION
Currently the code to stop the announce LED is run from a timer callback, which is an ISR context. The Blecon LED library cannot be run from ISR context because it attempts to acquire a mutex. This PR runs the code to stop the announce LED as a Zephyr delayed work item instead.

Also fixes the Blecon LED library header file to expose the heartbeat control function.